### PR TITLE
updated travis and composer versions, together with phive integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 vendor/
 composer.lock
+*.sh
+*.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/** @noinspection ALL */
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('vendor')
+    ->exclude('tools')
+    ->notPath('DependencyInjection/Configuration.php')
+    ->name('*.php');
+
+return PhpCsFixer\Config::create()
+    ->setLineEnding("\n")
+    ->setRules([
+        '@PSR2'                                     => true,
+        //        '@Symfony'                                  => true,
+        //        '@Symfony:risky'                            => true,
+        '@PHPUnit75Migration:risky'                 => true,
+        'binary_operator_spaces'                    => ['align_double_arrow' => true, 'align_equals' => true],
+        'blank_line_after_namespace'                => true,
+        'braces'                                    => true,
+        'class_definition'                          => true,
+        'no_extra_consecutive_blank_lines'          => true,
+        'no_multiline_whitespace_before_semicolons' => true,
+        'method_chaining_indentation'               => true,
+        'declare_strict_types'                      => true,
+        'elseif'                                    => true,
+        'encoding'                                  => true,
+        'final_class'                               => true,
+        'full_opening_tag'                          => true,
+        'no_closing_tag'                            => true,
+        'no_empty_statement'                        => true,
+        'no_empty_phpdoc'                           => true,
+        'no_empty_comment'                          => true,
+        'array_indentation'                         => true,
+        'array_syntax'                              => ['syntax' => 'short'],
+        'no_short_echo_tag'                         => true,
+        'no_spaces_around_offset'                   => true,
+        'no_unused_imports'                         => true,
+        'no_whitespace_before_comma_in_array'       => true,
+        'not_operator_with_successor_space'         => false,
+        'not_operator_with_space'                   => false,
+        'ordered_imports'                           => ['sortAlgorithm' => 'alpha'],
+        'trailing_comma_in_multiline_array'         => true,
+        'trim_array_spaces'                         => true,
+        'single_quote'                              => true,
+        'single_blank_line_at_eof'                  => false,
+        'visibility_required'                       => false,
+        'linebreak_after_opening_tag'               => true,
+        'strict_param'                              => true,
+        'strict_comparison'                         => true,
+        'is_null'                                   => true,
+        'yoda_style'                                => ['always_move_variable' => false, 'equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,65 @@
-language: php
+os:
+    - linux
 
-sudo: false
+language: php
 
 cache:
     directories:
-        - $HOME/.composer/cache/files
+        - "$HOME/.phive"
+        - "$HOME/.phive/phars"
+        - "$HOME/.cache/composer"
+        - "$HOME/.composer/cache"
+        - "$HOME/.gnupg"
 
 matrix:
+    allow_failures:
+        - php: 7.2snapshot
+        - php: 7.3snapshot
+        - php: 7.4snapshot
+        - php: master
     fast_finish: true
     include:
+        - stage: "PHP 7.2"
+          php: 7.2
+        - php: 7.2snapshot
         - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-        - php: 7.1
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-        - php: 7.1
         - php: 7.2
+          env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
+
+        - stage: "PHP 7.3"
+          php: 7.3
+        - php: 7.3snapshot
+        - php: 7.3
+          env: COMPOSER_FLAGS="--prefer-stable" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
+        - php: 7.3
+          env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
+        - php: 7.3
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
-        - php: 7.2
-          env: DEPENDENCIES="symfony/lts:^2"
-        - php: 7.2
-          env: DEPENDENCIES="symfony/lts:^3"
-        - php: 7.2
-          env: STABILITY="dev"
-    allow_failures:
-        - env: STABILITY="dev"
+
+        - stage: "PHP 7.4"
+          php: 7.4snapshot
+        - stage: "PHP 8.0"
+          php: master
 
 before_install:
+    - wget https://phar.io/releases/phive.phar
+    - wget https://phar.io/releases/phive.phar.asc
+    - gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys 0x9B2D5D79
+    - gpg --verify phive.phar.asc phive.phar
+    - chmod +x phive.phar
+    - mv phive.phar "$HOME/phive"
+
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
     - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
 
 install:
+    - if [ -n "$GH_AUTHTOKEN" ]; then composer config github-oauth.github.com ${GH_AUTHTOKEN}; fi;
     - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+    - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
+    - $HOME/phive install phpunit --trust-gpg-keys 4AA394086372C20A
     - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
-    - composer require symfony/console
-    - composer require symfony/messenger
 
 script:
-    - ./vendor/bin/phpunit
+    - ./tools/phpunit

--- a/Command/CreateSchemaCommand.php
+++ b/Command/CreateSchemaCommand.php
@@ -50,7 +50,7 @@ final class CreateSchemaCommand extends Command
     protected function configure()
     {
         $this->setDefinition([
-           new InputOption('force', null, InputOption::VALUE_NONE)
+            new InputOption('force', null, InputOption::VALUE_NONE),
         ]);
     }
 
@@ -62,11 +62,11 @@ final class CreateSchemaCommand extends Command
     {
         if (!$input->getOption('force')) {
             $output->writeln('You must use the --force option to execute this command.');
-            return null;
+            return -1;
         }
 
         $schema = new Schema();
-        $table = $schema->createTable($this->bag->get('jphooiveld_eventsauce.repository.doctrine.table'));
+        $table  = $schema->createTable($this->bag->get('jphooiveld_eventsauce.repository.doctrine.table'));
         $table->addColumn('event_id', 'guid');
         $table->addColumn('event_type', 'string', ['length' => 255]);
         $table->addColumn('aggregate_root_id', 'guid');
@@ -88,6 +88,6 @@ final class CreateSchemaCommand extends Command
 
         $output->writeln(sprintf('Table %s created', $this->bag->get('jphooiveld_eventsauce.repository.doctrine.table')));
 
-        return null;
+        return -1;
     }
 }

--- a/DependencyInjection/Compiler/AggregateRepositoryCompilerPass.php
+++ b/DependencyInjection/Compiler/AggregateRepositoryCompilerPass.php
@@ -62,9 +62,9 @@ final class AggregateRepositoryCompilerPass implements CompilerPassInterface
     /**
      * @param ContainerBuilder $container
      * @param string $serviceId
-     * @param string $className
+     * @param AggregateRootWithSnapshotting|string $className
      */
-    private function createAggregateRootWithSnapshottingService(ContainerBuilder $container, string $serviceId, string $className): void
+    private function createAggregateRootWithSnapshottingService(ContainerBuilder $container, string $serviceId, $className): void
     {
         $innerServiceId = sprintf('%s.inner', $serviceId);
 
@@ -84,9 +84,9 @@ final class AggregateRepositoryCompilerPass implements CompilerPassInterface
     /**
      * @param ContainerBuilder $container
      * @param string $serviceId
-     * @param string $className
+     * @param AggregateRoot|string $className
      */
-    private function createAggregateRootService(ContainerBuilder $container, string $serviceId, string $className): void
+    private function createAggregateRootService(ContainerBuilder $container, string $serviceId, $className): void
     {
         $arguments = [
             $className,

--- a/DependencyInjection/JphooiveldEventSauceExtension.php
+++ b/DependencyInjection/JphooiveldEventSauceExtension.php
@@ -45,7 +45,6 @@ final class JphooiveldEventSauceExtension extends Extension
 
             $definition = $container->getDefinition('jphooiveld_eventsauce.message_dispatcher.messenger');
             $definition->setArgument(0, new Reference($config['messenger']['service_bus']));
-
         } else {
             $container->registerForAutoconfiguration(Consumer::class)->addTag('eventsauce.consumer');
         }

--- a/JphooiveldEventSauceBundle.php
+++ b/JphooiveldEventSauceBundle.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle;
 
+use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Compiler\AggregateRepositoryCompilerPass;
 use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Compiler\ConsumerCompilerPass;
 use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Compiler\DelegatableUpcasterCompilerPass;
 use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Compiler\MessageDecoratorCompilerPass;
-use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Compiler\AggregateRepositoryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,5 +22,5 @@ final class JphooiveldEventSauceBundle extends Bundle
         $container->addCompilerPass(new DelegatableUpcasterCompilerPass());
         $container->addCompilerPass(new MessageDecoratorCompilerPass());
         $container->addCompilerPass(new AggregateRepositoryCompilerPass());
-   }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # JphooiveldEventSauceBundle
-
+[![Build Status](https://travis-ci.com/jphooiveld/EventSauceBundle.svg?branch=master)](https://travis-ci.com/jphooiveld/EventSauceBundle)
 ## Info
 
 This bundle integrates EventSauce and it's doctrine message repository into your symfony application.

--- a/Tests/Aggregate/Order.php
+++ b/Tests/Aggregate/Order.php
@@ -1,11 +1,12 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\Aggregate;
 
 use EventSauce\EventSourcing\AggregateRoot;
 use EventSauce\EventSourcing\AggregateRootBehaviour;
 
-class Order implements AggregateRoot
+final class Order implements AggregateRoot
 {
     use AggregateRootBehaviour;
 }

--- a/Tests/Command/CreateSchemaCommandTest.php
+++ b/Tests/Command/CreateSchemaCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\Command;
 
@@ -10,7 +11,12 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
-class CreateSchemaCommandTest extends KernelTestCase
+/**
+ * Class CreateSchemaCommandTest
+ * @package Jphooiveld\Bundle\EventSauceBundle\Tests\Command
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\Command\CreateSchemaCommand
+ */
+final class CreateSchemaCommandTest extends KernelTestCase
 {
     /**
      * @throws DBALException

--- a/Tests/ConsumableTraitTest.php
+++ b/Tests/ConsumableTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests;
 
@@ -8,7 +9,12 @@ use Jphooiveld\Bundle\EventSauceBundle\Tests\Consumer\TodoCreated;
 use Jphooiveld\Bundle\EventSauceBundle\Tests\Consumer\TodoStorage;
 use PHPUnit\Framework\TestCase;
 
-class ConsumableTraitTest extends TestCase
+/**
+ * Class ConsumableTraitTest
+ * @package Jphooiveld\Bundle\EventSauceBundle\Tests
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\ConsumableTrait
+ */
+final class ConsumableTraitTest extends TestCase
 {
     public function testHandle()
     {

--- a/Tests/Consumer/NotifyCreated.php
+++ b/Tests/Consumer/NotifyCreated.php
@@ -1,11 +1,12 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\Consumer;
 
 use EventSauce\EventSourcing\Consumer;
 use Jphooiveld\Bundle\EventSauceBundle\ConsumableTrait;
 
-class NotifyCreated implements Consumer
+final class NotifyCreated implements Consumer
 {
     use ConsumableTrait;
 

--- a/Tests/Consumer/TodoCreated.php
+++ b/Tests/Consumer/TodoCreated.php
@@ -1,10 +1,11 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\Consumer;
 
 use EventSauce\EventSourcing\Serialization\SerializablePayload;
 
-class TodoCreated implements SerializablePayload
+final class TodoCreated implements SerializablePayload
 {
     /**
      * @var int ID

--- a/Tests/Consumer/TodoStorage.php
+++ b/Tests/Consumer/TodoStorage.php
@@ -1,8 +1,9 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\Consumer;
 
-class TodoStorage
+final class TodoStorage
 {
     /**
      * @var int

--- a/Tests/DependencyInjection/Compiler/AggregateRepositoryCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AggregateRepositoryCompilerPassTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\DependencyInjection\Compiler;
 
@@ -10,7 +11,14 @@ use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class AggregateRepositoryCompilerPassTest extends TestCase
+/**
+ * Class AggregateRepositoryCompilerPassTest
+ * @package Jphooiveld\Bundle\EventSauceBundle\Tests\DependencyInjection\Compiler
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Compiler\AggregateRepositoryCompilerPass
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Configuration
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\JphooiveldEventSauceExtension
+ */
+final class AggregateRepositoryCompilerPassTest extends TestCase
 {
     /**
      * @throws ReflectionException

--- a/Tests/DependencyInjection/JphooiveldEventSauceExtensionTest.php
+++ b/Tests/DependencyInjection/JphooiveldEventSauceExtensionTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\DependencyInjection;
 
@@ -8,7 +9,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Parser;
 
-class JphooiveldEventSauceExtensionTest extends TestCase
+/**
+ * Class JphooiveldEventSauceExtensionTest
+ * @package Jphooiveld\Bundle\EventSauceBundle\Tests\DependencyInjection
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\JphooiveldEventSauceExtension
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Configuration
+ */
+final class JphooiveldEventSauceExtensionTest extends TestCase
 {
     /**
      * @throws \Exception
@@ -120,7 +127,7 @@ class JphooiveldEventSauceExtensionTest extends TestCase
     /**
      * @throws \Exception
      */
-    public function testRepositoryWitDoctrine()
+    public function testRepositoryWithDoctrine()
     {
         $configuration = new ContainerBuilder();
         $loader        = new JphooiveldEventSauceExtension();

--- a/Tests/JphooiveldEventSauceBundleTest.php
+++ b/Tests/JphooiveldEventSauceBundleTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests;
 
@@ -10,7 +11,12 @@ use Jphooiveld\Bundle\EventSauceBundle\JphooiveldEventSauceBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class JphooiveldEventSauceBundleTest extends TestCase
+/**
+ * Class JphooiveldEventSauceBundleTest
+ * @package Jphooiveld\Bundle\EventSauceBundle\Tests
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\JphooiveldEventSauceBundle
+ */
+final class JphooiveldEventSauceBundleTest extends TestCase
 {
     public function testCompilerPasses()
     {

--- a/Tests/MessengerDispatcherTest.php
+++ b/Tests/MessengerDispatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests;
 
@@ -9,7 +10,12 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class MessengerDispatcherTest extends TestCase
+/**
+ * Class MessengerDispatcherTest
+ * @package Jphooiveld\Bundle\EventSauceBundle\Tests
+ * @covers \Jphooiveld\Bundle\EventSauceBundle\MessengerDispatcher
+ */
+final class MessengerDispatcherTest extends TestCase
 {
     public function testDispatch()
     {

--- a/composer.json
+++ b/composer.json
@@ -2,30 +2,46 @@
     "name": "jphooiveld/eventsauce-bundle",
     "type": "symfony-bundle",
     "description": "EventSauce Bundle",
-    "keywords": ["EventSauce", "Event sourcing", "Symfony", "Bundle"],
+    "keywords": [
+        "EventSauce",
+        "Event sourcing",
+        "Symfony",
+        "Bundle"
+    ],
     "license": "MIT",
-	"authors": [
-		{
-			"name": "Jan Peter Hooiveld",
-			"email": "jphooiveld@gmail.com"
-		}
-	],	
+    "authors": [
+        {
+            "name": "Jan Peter Hooiveld",
+            "email": "jphooiveld@gmail.com"
+        },
+        {
+            "name": "Duncan de Boer",
+            "email": "duncan@charpand.nl"
+        }
+    ],
     "require": {
-        "php": "^7.1.3",
-		"eventsauce/eventsauce": "^0.7.0",
-		"eventsauce/doctrine-message-repository": "^0.7.0",
-        "symfony/framework-bundle": "^3.4|^4.0"
+        "php": "^7.2.5|^8.0",
+        "eventsauce/eventsauce": "^0.7.0",
+        "eventsauce/doctrine-message-repository": "^0.7.0",
+        "symfony/console": "^4.2|^5.0",
+        "symfony/messenger": "^4.2|^5.0",
+        "symfony/config": "^4.2|^5.0",
+        "symfony/dependency-injection": "^4.2|^5.0",
+        "symfony/http-kernel": "^4.2|^5.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "@stable",
-		"phpunit/phpunit": "~7.0"
+        "doctrine/dbal": "^2.6.0",
+        "roave/security-advisories": "dev-master",
+        "symfony/framework-bundle": "^4.2|^5.0"
     },
     "suggest": {
         "symfony/console": "Using symfony console to create event sourcing table",
         "symfony/messenger": "Using symfony messenger as event bus"
     },
     "autoload": {
-        "psr-4": { "Jphooiveld\\Bundle\\EventSauceBundle\\": "" },
+        "psr-4": {
+            "Jphooiveld\\Bundle\\EventSauceBundle\\": ""
+        },
         "exclude-from-classmap": [
             "/Tests/"
         ]

--- a/phive.xml
+++ b/phive.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpunit" version="^8.4.3" installed="8.4.3" location="./tools/phpunit" copy="false"/>
+  <phar name="phpstan" version="^0.11.19" installed="0.11.19" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^2.16.0" installed="2.16.0" location="./tools/php-cs-fixer" copy="false"/>
+</phive>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,11 @@
 parameters:
     ignoreErrors:
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\).#'
+    level: max
+    paths:
+        - Command
+        - DependencyInjection
+        - Resources
     excludes_analyse:
         - *Test.php
         - vendor

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php">
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.3/phpunit.xsd"
+         colors="true"
+         verbose="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         backupGlobals="true"
+         forceCoversAnnotation="true"
+         executionOrder="depends,defects"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <ini name="display_errors" value="on"/>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="log_errors_max_len" value="0"/>
+        <ini name="xdebug.show_exception_trace" value="0"/>
+        <ini name="zend.assertions" value="1"/>
+        <ini name="assert.exception" value="1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="date.timezone" value="Europe/Amsterdam"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+    </php>
     <testsuites>
         <testsuite name="JphooiveldEventSauceBundle Test Suite">
             <directory>./Tests/</directory>

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,3 @@
+# Created by .ignore support plugin (hsz.mobi)
+*
+!.gitignore


### PR DESCRIPTION
updates to travis:
- disallow PHP 7.1
- allow PHP 7.3
- allow PHP 7.4
- allow PHP 8.0
Upgrade composer packages:
- removal of frameworkbundle in require
- added some new components
- removed 'tools' to phive.xml