### PR TITLE
The root-node of the tree is the same as the alias of the extension

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ final class Configuration implements ConfigurationInterface
             $validJsonConstants[] = JSON_THROW_ON_ERROR;
         }
 
-        $treeBuilder = new TreeBuilder('jphooiveld_eventsauce');
+        $treeBuilder = new TreeBuilder('jphooiveld_event_sauce');
 
         //@formatter:off
         $treeBuilder->getRootNode()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+
+namespace Jphooiveld\Bundle\EventSauceBundle\Tests\DependencyInjection;
+
+use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\Configuration;
+use Jphooiveld\Bundle\EventSauceBundle\DependencyInjection\JphooiveldEventSauceExtension;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationTest extends TestCase
+{
+
+    public function testTreeRootNameMatchesExtensionAlias()
+    {
+        $configuration = new Configuration();
+        $extension     = new JphooiveldEventSauceExtension();
+
+        self::assertSame(
+            $extension->getAlias(),
+            $configuration->getConfigTreeBuilder()->buildTree()->getName()
+        );
+
+    }
+
+}


### PR DESCRIPTION
Semantically those two values have to be the same. That wasn't an issue to this point, as Symfony does not check that explicitly. But for https://symfony.com/blog/new-in-symfony-5-3-config-builder-classes to work this fix needs to be applied.