### PR TITLE
Bump `eventsauce/eventsauce` to 1.3, `php` to 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os:
 
 language: php
 
+dist: bionic
+
 cache:
     directories:
         - $HOME/.cache/composer
@@ -16,38 +18,23 @@ env:
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
 
 matrix:
-    allow_failures:
-        - php: 7.2snapshot
-        - php: 7.3snapshot
-        - php: 7.4snapshot
-        - php: master
     fast_finish: true
     include:
-        - php: 7.2
+        - php: 8.0
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
-        - php: 7.3
-          env: COMPOSER_FLAGS="--prefer-stable" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
-        - php: 7.4
+        - php: 8.1.2
           env: COMPOSER_FLAGS="--prefer-stable" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
-        - php: 7.2
-        - php: 7.3
+        - php: 8.1.2
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
-        - php: 7.4
 
-        - php: 7.2
+        - php: 8.0
           env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
-        - php: 7.3
-          env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
-        - php: 7.4
+        - php: 8.1.2
           env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
 
-        - php: 7.2snapshot
-        - php: 7.3snapshot
-        - php: 7.4snapshot
-
-        - stage: "PHP 8.0"
-          php: master
+        - php: 8.0snapshot
+        - php: 8.1.2snapshot
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ matrix:
     include:
         - php: 8.0
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
-        - php: 8.1.2
+        - php: 8.1.0
           env: COMPOSER_FLAGS="--prefer-stable" SYMFONY_DEPRECATIONS_HELPER="max[self]=0"
 
-        - php: 8.1.2
+        - php: 8.1.0
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
 
         - php: 8.0
           env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
-        - php: 8.1.2
+        - php: 8.1.0
           env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
 
         - php: 8.0snapshot
-        - php: 8.1.2snapshot
+        - php: 8.1.0snapshot
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ matrix:
           env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
 
         - php: 8.0
-          env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
+          env: SYMFONY_REQUIRE="4.*" STABILITY="dev"
         - php: 8.1.0
-          env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
+          env: SYMFONY_REQUIRE="4.*" STABILITY="dev"
 
         - php: 8.0snapshot
         - php: 8.1.0snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,9 @@ matrix:
         - php: 8.0
           env: SYMFONY_REQUIRE="4.*" STABILITY="dev"
         - php: 8.1.0
-          env: SYMFONY_REQUIRE="4.*" STABILITY="dev"
+          env: DEPENDENCIES="symfony/lts:^4" STABILITY="dev"
 
         - php: 8.0snapshot
-        - php: 8.1.0snapshot
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/Command/CreateSchemaCommand.php
+++ b/Command/CreateSchemaCommand.php
@@ -72,7 +72,7 @@ final class CreateSchemaCommand extends Command
         $table->addColumn('aggregate_root_id', 'guid');
         $table->addColumn('aggregate_root_version', 'integer');
         $table->addColumn('time_of_recording', 'datetime_immutable');
-        $table->addColumn('payload', 'json_array', ['PlatformOptions' => ['jsonb' => true]]);
+        $table->addColumn('payload', 'json', ['PlatformOptions' => ['jsonb' => true]]);
         $table->setPrimaryKey(['event_id']);
         $table->addIndex(['aggregate_root_id']);
         $table->addIndex(['time_of_recording']);

--- a/Tests/Consumer/NotifyCreated.php
+++ b/Tests/Consumer/NotifyCreated.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Jphooiveld\Bundle\EventSauceBundle\Tests\Consumer;
 
-use EventSauce\EventSourcing\Consumer;
+use EventSauce\EventSourcing\MessageConsumer;
 use Jphooiveld\Bundle\EventSauceBundle\ConsumableTrait;
 
-final class NotifyCreated implements Consumer
+final class NotifyCreated implements MessageConsumer
 {
     use ConsumableTrait;
 

--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,16 @@
     "require": {
         "php": "^7.2.5|^8.0",
         "ext-json": "*",
-        "eventsauce/eventsauce": "^0.8",
-        "eventsauce/doctrine-message-repository": "^0.8",
+        "eventsauce/eventsauce": "^1.3",
         "symfony/console": "^4.2|^5.0",
         "symfony/messenger": "^4.2|^5.0",
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^4.2|^5.0",
-        "symfony/http-kernel": "^4.2|^5.0"
+        "symfony/http-kernel": "^4.2|^5.0",
+        "eventsauce/message-repository-for-doctrine": "^0.2.1"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.6.0",
+        "doctrine/dbal": "^3.1",
         "roave/security-advisories": "dev-master",
         "symfony/framework-bundle": "^4.2|^5.0",
         "symfony/phpunit-bridge": "^5.0",
@@ -40,7 +40,8 @@
         "phpstan/phpstan-deprecation-rules": "^0.12.2",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.19",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "symfony/yaml": "^4.2|^6.0"
     },
     "suggest": {
         "symfony/console": "Using symfony console to create event sourcing table",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "eventsauce/eventsauce": "^1.3",
         "symfony/console": "^4.2|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.2",
         "ext-json": "*",
         "eventsauce/eventsauce": "^1.3",
         "symfony/console": "^4.2|^5.0",


### PR DESCRIPTION
This bumps EventSauce dependencies to 1.3

* Bumped the library version
* Bumped PHP to 8.0 at least
* Updated build matrix accordingly
* `symfony/lts` has [deprecated](https://symfony.com/doc/4.4/bundles/best_practices.html#continuous-integration) in favour of using `SYMFONY_REQUIRE`
* Migrated to `doctrine/dbal`@`3.1`
* Extracted direct test dependency on `symfony/yaml`