### PR TITLE
Update dep on `roave/security-advisories` to `dev-latest`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "doctrine/dbal": "^2.6.0",
-        "roave/security-advisories": "dev-master",
+        "roave/security-advisories": "dev-latest",
         "symfony/framework-bundle": "^4.2|^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "phpstan/phpstan-phpunit": "^0.12.8",


### PR DESCRIPTION
[Usage guide for `roave/security-advisories`](https://github.com/Roave/SecurityAdvisories#usage) suggests using `dev-latest` instead of `dev-master`. This fixes the issue by moving the required branch, protecting from possible future BC breakages (probably Roave do not guarantee that `dev-master` will always stay available).